### PR TITLE
Ignore inline comments in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,7 +192,11 @@ func NewConfig(metadata map[string][]Parameter, logger *logging.Logger) (*Config
 }
 
 func (conf *Config) Parse(path string) error {
-	data, err := ini.LoadSources(ini.LoadOptions{AllowPythonMultilineValues: true}, path) //ini.Load(path)
+	options := ini.LoadOptions{
+		AllowPythonMultilineValues: true,
+		IgnoreInlineComment:        true,
+	}
+	data, err := ini.LoadSources(options, path)
 	if err != nil {
 		return err
 	}

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -18,6 +18,13 @@ var CONFIG_CONTENT = `
 log_file=/var/tmp/test.log
 allow_exec=false
 
+[sensu]
+checks={"checks":
+				{"test":
+					{"command": "echo 'one'; echo 'two'"}
+				}
+		  }
+
 [amqp1]
 port=666
 
@@ -81,6 +88,9 @@ func TestConfigValues(t *testing.T) {
 	assert.Equal(t, "/var/tmp/test.log", conf.Sections["default"].Options["log_file"].GetString(), "Did not parse correctly")
 	assert.Equal(t, false, conf.Sections["default"].Options["allow_exec"].GetBool(), "Did not parse correctly")
 	assert.Equal(t, 666, conf.Sections["amqp1"].Options["port"].GetInt(), "Did not parse correctly")
+
+	checks := "{\"checks\":\n{\"test\":\n{\"command\": \"echo 'one'; echo 'two'\"}\n}\n}"
+	assert.Equal(t, checks, conf.Sections["sensu"].Options["checks"].GetString(), "Did not parse correctly")
 	os.Remove(file.Name())
 }
 


### PR DESCRIPTION
We need to ignore inline comments to enable character ";" in checks command.
In INI format semicolon is used for comments.