### PR TITLE
Use the newest apputils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,7 @@ module github.com/infrawatch/collectd-sensubility
 go 1.13
 
 require (
-	github.com/apache/qpid-proton v0.0.0-20210222174104-6353ad99c23d // indirect
-	github.com/infrawatch/apputils v0.0.0-20230608151936-0c90918c3e1e
+	github.com/infrawatch/apputils v0.0.0-20240430082726-ed39d5d5ed39
 	github.com/kr/text v0.2.0 // indirect
-	github.com/smartystreets/goconvey v1.8.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 )


### PR DESCRIPTION
We need newest apputils to get rid of qpid-proton usage.